### PR TITLE
Fix for issue #82

### DIFF
--- a/src/main/java/brickhouse/udf/collect/UnionUDAF.java
+++ b/src/main/java/brickhouse/udf/collect/UnionUDAF.java
@@ -83,7 +83,7 @@ public class UnionUDAF extends AbstractGenericUDAFResolver {
 			super.init(m, parameters);
 			// init output object inspectors
 			// The output of a partial aggregation is a list
-			if (m == Mode.PARTIAL1) {
+			if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
 				inputMapOI = (MapObjectInspector) parameters[0];
 				
 				inputKeyOI = inputMapOI.getMapKeyObjectInspector();


### PR DESCRIPTION
See https://github.com/klout/brickhouse/issues/82

Sometimes the variable inputMapOI is null in UnionUDAF, leading to a NPE
in the iterate method. This seems to occur when the init method is
called with Mode.COMPLETE rather than Mode.PARTIAL.

This bug surfaced for us after upgrading to Hive 0.13.
